### PR TITLE
Add validations to interactions

### DIFF
--- a/app/interactions/geocoder/geocode.rb
+++ b/app/interactions/geocoder/geocode.rb
@@ -19,6 +19,8 @@ module Geocoder
   class Geocode < ActiveInteraction::Base
     string :address
 
+    validates :address, presence: true
+
     def execute
       response = Rails.cache.fetch(cache_key) do
         response = geocoder.geocode(address)

--- a/app/interactions/weather/fetch.rb
+++ b/app/interactions/weather/fetch.rb
@@ -20,6 +20,10 @@ module Weather
     string :city, default: nil
     string :country_code, default: 'us'
 
+    validates :zip_code, presence: true, if: -> { city.blank? }
+    validates :city, presence: true, if: -> { zip_code.blank? }
+    validates :country_code, presence: true
+
     attr_reader :was_cached, :last_updated_at
 
     def execute

--- a/spec/interactions/geocoder/geocode_spec.rb
+++ b/spec/interactions/geocoder/geocode_spec.rb
@@ -4,40 +4,60 @@ require 'rails_helper'
 
 RSpec.describe Geocoder::Geocode do
   let(:address) { '1 Infinite Loop, Cupertino, CA' }
-  let(:api_response) do
-    JSON.parse(Rails.root.join('spec/fixtures/open_cage/geocode/valid.json').read)
+
+  describe 'validations' do
+    it 'is invalid when address is blank' do
+      outcome = described_class.run(address: '')
+
+      expect(outcome).to be_invalid
+    end
   end
 
-  before do
-    stub_request(:get, "https://api.opencagedata.com/geocode/v1/json?key=#{ENV.fetch('OPEN_CAGE_API_KEY', nil)}&q=#{CGI.escape(address)}") # rubocop:disable Metrics/LineLength
-      .to_return(
-        status: 200,
-        body: api_response.to_json,
-        headers: { 'Content-Type' => 'application/json' }
-      )
-  end
+  context 'when the address is valid' do
+    let(:api_response) do
+      JSON.parse(Rails.root.join('spec/fixtures/open_cage/geocode/valid.json').read)
+    end
 
-  it '#zip_code' do
-    outcome = described_class.run(address:)
+    before do
+      stub_request(:get, "https://api.opencagedata.com/geocode/v1/json?key=#{ENV.fetch('OPEN_CAGE_API_KEY', nil)}&q=#{CGI.escape(address)}") # rubocop:disable Metrics/LineLength
+        .to_return(
+          status: 200,
+          body: api_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+    end
 
-    expect(outcome.result.zip_code).to eq('95014')
-  end
+    it 'responds with the zip_code' do
+      outcome = described_class.run(address:)
 
-  it '#city' do
-    outcome = described_class.run(address:)
+      expect(outcome.result.zip_code).to eq('95014')
+    end
 
-    expect(outcome.result.city).to eq('Cupertino')
-  end
+    it 'responds with the city' do
+      outcome = described_class.run(address:)
 
-  it '#country_code' do
-    outcome = described_class.run(address:)
+      expect(outcome.result.city).to eq('Cupertino')
+    end
 
-    expect(outcome.result.country_code).to eq('us')
+    it 'responds with the country_code' do
+      outcome = described_class.run(address:)
+
+      expect(outcome.result.country_code).to eq('us')
+    end
   end
 
   context 'when the API key is invalid' do
     let(:api_response) do
       JSON.parse(Rails.root.join('spec/fixtures/open_cage/geocode/invalid_api_key.json').read)
+    end
+
+    before do
+      stub_request(:get, "https://api.opencagedata.com/geocode/v1/json?key=#{ENV.fetch('OPEN_CAGE_API_KEY', nil)}&q=#{CGI.escape(address)}") # rubocop:disable Metrics/LineLength
+        .to_return(
+          status: 200,
+          body: api_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
     end
 
     it 'is invalid' do
@@ -48,6 +68,15 @@ RSpec.describe Geocoder::Geocode do
   context 'when the address is invalid' do
     let(:api_response) do
       JSON.parse(Rails.root.join('spec/fixtures/open_cage/geocode/no_results.json').read)
+    end
+
+    before do
+      stub_request(:get, "https://api.opencagedata.com/geocode/v1/json?key=#{ENV.fetch('OPEN_CAGE_API_KEY', nil)}&q=#{CGI.escape(address)}") # rubocop:disable Metrics/LineLength
+        .to_return(
+          status: 200,
+          body: api_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
     end
 
     it 'is invalid' do

--- a/spec/interactions/weather/fetch_spec.rb
+++ b/spec/interactions/weather/fetch_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe Weather::Fetch do
   let(:city) { 'Cupertino' }
   let(:api_key) { OpenWeather::Client.new.api_key }
 
+  describe 'validations' do
+    it 'is invalid when both zip_code and city are blank' do
+      outcome = described_class.run(zip_code: nil, city: nil)
+
+      expect(outcome).to be_invalid
+    end
+  end
+
   context 'when both zip_code and city are passed' do
     let(:api_response) do
       JSON.parse(Rails.root.join('spec/fixtures/open_weather/current_weather/valid.json').read)


### PR DESCRIPTION
This PR adds missing validations to interactions:

- `Geocoder::Geocode`: presence of address
- `Weather::Fetch`: presence of zip code or city

With this validations, the UI is better able to respond to invalid inputs (e.g. no address entered).